### PR TITLE
pushpkg: clean up the debs folder after uploading

### DIFF
--- a/pushpkg/pushpkg
+++ b/pushpkg/pushpkg
@@ -31,3 +31,4 @@ if [ -z "$2" ]; then
 fi
 
 rsync --ignore-existing -rlOvhze ssh --progress debs/* ${1}@repo.aosc.io:/mirror/debs/pool/${2}/${3:-main}
+rm -rv debs/*


### PR DESCRIPTION
I always forget to clean up OUTPUT/debs/* after uploading a package, so I write it in pushpkg.